### PR TITLE
docs: add upstream interaction policy to all crate AGENTS.md files

### DIFF
--- a/cashu-core-lite/AGENTS.md
+++ b/cashu-core-lite/AGENTS.md
@@ -36,3 +36,7 @@ Core types for Cashu V4 token operations on embedded hardware:
 ```bash
 cargo test
 ```
+
+## Upstream Interaction Policy
+
+**NEVER file PRs or issues on upstream projects without human review and approval.** AI-generated bug diagnoses can be confidently wrong. Document findings in Amperstrand repos first and let a human decide whether to escalate.

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -299,3 +299,7 @@ across 1200 total commands. Upstream embassy is stable on our hardware.
 **Conclusion**: No evidence of IN endpoint hang on STM32F469I-DISCO. Keep upstream
 `84444a19` pin. Test branches remain available if a minimal reproducer surfaces.
 See issue #17 for full details.
+
+## Upstream Interaction Policy
+
+**NEVER file PRs or issues on upstream projects (embassy-rs, stm32-rs, DougAnderson444, etc.) without human review and approval.** AI-generated bug diagnoses can be confidently wrong — see the SNAK investigation retrospective above (PR #5738 was a misdiagnosis caused by probe-rs artifacts, not a real bug). File issues and PRs on Amperstrand repos only. If you believe you've found an upstream bug, write it up in an Amperstrand issue with evidence and let a human decide whether to escalate.

--- a/host-mint-tool/AGENTS.md
+++ b/host-mint-tool/AGENTS.md
@@ -29,3 +29,7 @@ Uses the same USB CDC binary protocol as the firmware. See `firmware/AGENTS.md` 
 
 - `serialport` — Cross-platform serial communication
 - `hex` — Hex encoding/decoding
+
+## Upstream Interaction Policy
+
+**NEVER file PRs or issues on upstream projects (embassy-rs, stm32-rs, etc.) without human review and approval.** AI-generated bug diagnoses can be confidently wrong. Document findings in Amperstrand repos first and let a human decide whether to escalate.

--- a/micronuts-app/AGENTS.md
+++ b/micronuts-app/AGENTS.md
@@ -79,3 +79,7 @@ Defined in `hardware.rs`. All methods use `impl Future` RPITIT syntax (async tra
 - 5 state machine tests — screen flow, transitions
 - 5 protocol codec tests — frame encode/decode
 - 30 cashu-core-lite tests — crypto, hash-to-curve, token encoding
+
+## Upstream Interaction Policy
+
+**NEVER file PRs or issues on upstream projects (embassy-rs, stm32-rs, etc.) without human review and approval.** AI-generated bug diagnoses can be confidently wrong. Document findings in Amperstrand repos first and let a human decide whether to escalate.


### PR DESCRIPTION
## Summary

- Add "Upstream Interaction Policy" section to `firmware/AGENTS.md`, `micronuts-app/AGENTS.md`, `host-mint-tool/AGENTS.md`, and `cashu-core-lite/AGENTS.md`
- Policy: NEVER file PRs or issues on upstream projects (embassy-rs, stm32-rs, etc.) without human review and approval
- References the SNAK misdiagnosis (embassy-rs#5738) as a cautionary example

## Context

AI-assisted development confidently filed embassy-rs/embassy#5738 claiming a USB IN endpoint bug, which turned out to be a probe-rs artifact. This guardrail prevents that from happening again across all Amperstrand crates.