### PR TITLE
fix: USB OTG FS PHY reset for reliable re-enumeration after st-flash

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -203,6 +203,52 @@ async fn main(spawner: Spawner) {
         crate::log_info!("Boot splash complete");
     }
 
+    // After a soft reset (SYSRESETREQ from st-flash), the USB OTG FS peripheral
+    // can be left in an inconsistent state where the PHY doesn't re-enumerate.
+    // Cycling the RCC clock + core soft reset + PHY power cycle ensures a clean
+    // start regardless of how we got here. See ccid-firmware-rs issue #15.
+    {
+        let rcc = stm32_metapac::RCC;
+
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(false));
+        cortex_m::asm::delay(100);
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(true));
+
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(true));
+        cortex_m::asm::delay(100);
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(false));
+        cortex_m::asm::delay(100);
+
+        // USB_OTG_FS_GLOBAL base: 0x5000_0000
+        // GRSTCTL offset: 0x010, GCCFG offset: 0x038
+        let otg_global = 0x5000_0000usize as *mut u32;
+        unsafe {
+            // GRSTCTL.AHBIDL (bit 31) — wait for AHB idle before reset
+            let mut timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & (1 << 31) == 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GRSTCTL.CSRST (bit 0) — core soft reset, self-clearing
+            otg_global.add(0x010 / 4).write_volatile(1);
+            timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & 1 != 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GCCFG.PWRDWN (bit 16) — PHY power cycle
+            otg_global.add(0x038 / 4).write_volatile(0);
+            cortex_m::asm::delay(100);
+            otg_global.add(0x038 / 4).write_volatile(1 << 16);
+        }
+    }
+
     crate::log_info!("Initializing USB...");
     static EP_OUT_BUFFER: StaticCell<[u8; 512]> = StaticCell::new();
     let ep_out_buffer = EP_OUT_BUFFER.init([0u8; 512]);


### PR DESCRIPTION
## Summary

Fixes #34 — USB OTG FS doesn't re-enumerate after `st-flash` soft reset.

Adds an explicit PHY reset sequence between `embassy_stm32::init()` and `Driver::new_fs()`:

1. RCC AHB2ENR.OTGFSEN clock cycle (disable → enable)
2. RCC AHB2RSTR.OTGFSRST peripheral reset (assert → deassert)
3. GRSTCTL.CSRST core soft reset
4. GCCFG.PWRDWN PHY power cycle (clear → set)

## Why This Is Needed

After `st-flash` (SYSRESETREQ without NRST), the USB PHY retains stale state. Neither `embassy-usb-synopsys-otg` nor `embassy-stm32`'s RCC init performs the full reset sequence needed to unwedge the PHY.

## Verification

Same fix hardware-verified on STM32F746-DISCO in ccid-firmware-rs (commit 28e6fee, issue #15). The STM32F469 uses an identical OTG FS peripheral at the same base address (0x5000_0000).

## Related

- ccid-firmware-rs#15 — original fix (STM32F746, hardware-verified)
- Amperstrand/microfips#105 — same fix for microfips
- Amperstrand/gm65-scanner#56 — same fix for gm65-scanner (sync + async)